### PR TITLE
Changes to support the PROD archive S3 bucket being in Data Lake AWS account.

### DIFF
--- a/email-mvt-archive/index.ts
+++ b/email-mvt-archive/index.ts
@@ -17,7 +17,7 @@ class EmailMVTLogArchiverStack extends cdk.Stack {
       allowedValues: [StackStage.Code, StackStage.Prod],
     });
 
-    const defaultBucketName = new cdk.CfnParameter(this, 'DestinationBucket', {
+    const destinationBucketName = new cdk.CfnParameter(this, 'DestinationBucket', {
       type: 'String',
       description: `S3 bucket to copy logs into. Make sure the Lambda has write access into the bucket and that it's encrypted, has versioning disabled, and has a 28 day retention policy.`
     });
@@ -25,7 +25,7 @@ class EmailMVTLogArchiverStack extends cdk.Stack {
     const sourceBucketName = Fn.importValue(`EmailMVTPixel-Logs-S3Bucket-${stage.valueAsString}`);
 
     // The code that defines your stack goes here
-    new EmailMVTLogArchiver(this, this.node.tryGetContext('App'), { stage: stage.valueAsString, sourceBucketName, defaultBucketName: defaultBucketName.valueAsString });
+    new EmailMVTLogArchiver(this, this.node.tryGetContext('App'), { stage: stage.valueAsString, sourceBucketName, destinationBucketName: destinationBucketName.valueAsString });
   }
 }
 

--- a/email-mvt-archive/lambda-hander.js
+++ b/email-mvt-archive/lambda-hander.js
@@ -17,6 +17,7 @@ exports.handler = async () => {
     }).promise()
       .then(() => Promise.resolve('skipped'))
       .catch(() => s3.copyObject({
+        ACL: 'bucket-owner-read',
         Bucket: `${process.env.destination_s3_bucket}/dt=${destinationFolder}`,
         CopySource: `${process.env.source_s3_bucket}/${source}`,
         Key: source

--- a/email-mvt-archive/lib/EmailMVTLogArchiver.ts
+++ b/email-mvt-archive/lib/EmailMVTLogArchiver.ts
@@ -13,7 +13,7 @@ import {RuleTargetInput} from "@aws-cdk/aws-events";
 export interface EmailMVTLogArchiverProps {
   stage: string;
   sourceBucketName: string;
-  defaultBucketName: string;
+  destinationBucketName: string;
 }
 
 export class EmailMVTLogArchiver extends Construct {
@@ -41,13 +41,13 @@ export class EmailMVTLogArchiver extends Construct {
           actions: ['s3:GetObject', 's3:ListBucket']
         }),
         new iam.PolicyStatement({
-          resources: [`arn:aws:s3:::archive-${props.sourceBucketName}/*`],
-          actions: ['s3:GetObject','s3:PutObject']
+          resources: [`arn:aws:s3:::${props.destinationBucketName}/*`],
+          actions: ['s3:GetObject','s3:PutObject','s3:PutObjectAcl']
         }),
       ],
       environment: {
         'source_s3_bucket': props.sourceBucketName,
-        'destination_s3_bucket': props.defaultBucketName
+        'destination_s3_bucket': props.destinationBucketName
       }
     });
 

--- a/email-mvt-archive/template.yaml
+++ b/email-mvt-archive/template.yaml
@@ -74,16 +74,13 @@ Resources:
           - Action:
               - s3:GetObject
               - s3:PutObject
+              - s3:PutObjectAcl
             Effect: Allow
             Resource:
               Fn::Join:
                 - ""
-                - - arn:aws:s3:::archive-
-                  - Fn::ImportValue:
-                      Fn::Join:
-                        - ""
-                        - - EmailMVTPixel-Logs-S3Bucket-
-                          - Ref: Stage
+                - - "arn:aws:s3:::"
+                  - Ref: DestinationBucket
                   - /*
         Version: "2012-10-17"
       PolicyName: EmailMVTLogArchiverServiceRoleDefaultPolicy2B34FF4D
@@ -117,6 +114,7 @@ Resources:
               }).promise()
                 .then(() => Promise.resolve('skipped'))
                 .catch(() => s3.copyObject({
+                  ACL: 'bucket-owner-read',
                   Bucket: `${process.env.destination_s3_bucket}/dt=${destinationFolder}`,
                   CopySource: `${process.env.source_s3_bucket}/${source}`,
                   Key: source


### PR DESCRIPTION
1. Changes to the destination bucket files' ACL settings to support the PROD archive S3 bucket (ophan-raw-email-mvt-pixel-logs) sitting in the Data Lake AWS account. See: https://github.com/guardian/ophan-data-lake/pull/4408
2. Fixed a typo where I called a variable 'defaultBucketName' when I meant to use 'destinationBucketName'.