### PR TITLE
Partition from filename

### DIFF
--- a/email-mvt-archive/lib/EmailMVTLogArchiver.ts
+++ b/email-mvt-archive/lib/EmailMVTLogArchiver.ts
@@ -25,7 +25,7 @@ export class EmailMVTLogArchiver extends Construct {
       code: new lambda.InlineCode(fs.readFileSync('lambda-hander.js',{ encoding: 'utf-8' })),
       handler: 'index.handler',
       runtime: Runtime.NODEJS_8_10,
-      memorySize: 256,
+      memorySize: 512,
       functionName: `EmailMVTLogArchiver-${props.stage}`,
       timeout: Duration.seconds(60),
       initialPolicy: [

--- a/email-mvt-archive/template.yaml
+++ b/email-mvt-archive/template.yaml
@@ -97,6 +97,8 @@ Resources:
 
           const s3 = new aws.S3();
 
+          const filenameDateRegex = /(\d\d\d\d-\d\d-\d\d)-\d\d/;
+
 
           async function listAllObjects(s3Objects, Bucket, ContinuationToken){
             const { Contents, IsTruncated, NextContinuationToken } = await s3.listObjectsV2({ Bucket, ContinuationToken }).promise();
@@ -110,12 +112,12 @@ Resources:
           exports.handler = async () => {
             const allObjects = [];
             await listAllObjects(allObjects, process.env.source_s3_bucket);
-            const objectsWithDesiredFolder = allObjects.map(s3object => {
-              const year = '' + s3object.LastModified.getFullYear();
-              const month = '' + (s3object.LastModified.getMonth()+1);
-              const day = '' + s3object.LastModified.getDate();
-              return [s3object.Key].concat(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
-            });
+            const objectsWithDesiredFolder = allObjects
+              .filter(s3object => filenameDateRegex.test(s3object.Key))
+              .map(s3object => {
+                const dateFromFilename = s3object.Key.match(filenameDateRegex)[1];
+                return [s3object.Key, dateFromFilename];
+              });
             const promises = objectsWithDesiredFolder.map(tuple => {
               const [source, destinationFolder] = tuple;
               return s3.headObject({
@@ -158,7 +160,7 @@ Resources:
           - ""
           - - EmailMVTLogArchiver-
             - Ref: Stage
-      MemorySize: 256
+      MemorySize: 512
       Timeout: 60
     DependsOn:
       - EmailMVTLogArchiverServiceRoleDefaultPolicy2B34FF4D


### PR DESCRIPTION
Decide the destination partition based on file name rather than the last modified date.

This change fixes a bug in the archiver where files from a previous day appeared in the next day's partition in the specific case where CloudFront was busy writing the file during the UTC time boundary, meaning the filename and last modified date contained two different dates. It's much easier for the Spark partition processor to process files that contain tomorrow's access logs rather than than yesterday's.

https://trello.com/c/pjSBtC9e