### PR TITLE
A tiny bit more memory for the archiver Lambda

### DIFF
--- a/email-mvt-archive/lib/EmailMVTLogArchiver.ts
+++ b/email-mvt-archive/lib/EmailMVTLogArchiver.ts
@@ -25,7 +25,7 @@ export class EmailMVTLogArchiver extends Construct {
       code: new lambda.InlineCode(fs.readFileSync('lambda-hander.js',{ encoding: 'utf-8' })),
       handler: 'index.handler',
       runtime: Runtime.NODEJS_8_10,
-      memorySize: 512,
+      memorySize: 768,
       functionName: `EmailMVTLogArchiver-${props.stage}`,
       timeout: Duration.seconds(60),
       initialPolicy: [

--- a/email-mvt-archive/template.yaml
+++ b/email-mvt-archive/template.yaml
@@ -160,7 +160,7 @@ Resources:
           - ""
           - - EmailMVTLogArchiver-
             - Ref: Stage
-      MemorySize: 512
+      MemorySize: 768
       Timeout: 60
     DependsOn:
       - EmailMVTLogArchiverServiceRoleDefaultPolicy2B34FF4D


### PR DESCRIPTION
A tiny bit more memory for the Lambda - 512MB was just under 100MB too small for 27 days worth of files - 28 days is the retention period so this small increase should be the last for a few months.