### PR TITLE
Update Snyk workflow to use current default branch name

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,7 +4,7 @@ name: Snyk
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
Updates the Snyk workflow trigger to use the current default branch name, `master`. Preferably this should be renamed, but in the meantime this will at least set up Snyk correctly.