### PR TITLE
Ensure only files from yesterday or before are copied over in the archive job

### DIFF
--- a/email-mvt-archive/src/email-mvt-pixel-log-archiver-lambda.ts
+++ b/email-mvt-archive/src/email-mvt-pixel-log-archiver-lambda.ts
@@ -21,6 +21,7 @@ interface TransferableFile {
 }
 
 function getTransferableFiles(allS3Objects: ObjectList) {
+  const [dateToday] = new Date().toISOString().split('T');
   return allS3Objects
     .filter(s3object => s3object.Key && filenameDateRegex.test(s3object.Key))
     .map(s3object => {
@@ -29,8 +30,10 @@ function getTransferableFiles(allS3Objects: ObjectList) {
         const matches = s3objectValue.match(filenameDateRegex);
         if (matches && matches.length > 0 && matches[1]) {
           const dateFromFilename = matches[1];
-          const tuple: TransferableFile = {sourceFileName: s3objectValue, destinationFolder: dateFromFilename};
-          return tuple;
+          if (dateFromFilename < dateToday) { // Only copy over data before today
+            const tuple: TransferableFile = {sourceFileName: s3objectValue, destinationFolder: dateFromFilename};
+            return tuple;
+          }
         }
       }
     }).filter((item): item is TransferableFile => !!item);


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Ensure only files from yesterday or before are copied over in the archiver job to stop a handful of today's files being copied over when the job runs at 1:10am UTC
