### PR TITLE
Remove bucket name from Riff Raff config

### DIFF
--- a/.github/workflows/email-mvt-archive-build.yml
+++ b/.github/workflows/email-mvt-archive-build.yml
@@ -1,6 +1,6 @@
 name: Build email-mvt-archive
 
-on: 
+on:
   pull_request:
     branches:
       - main
@@ -87,7 +87,6 @@ jobs:
                   - email-mvt-archive/target/email-mvt-pixel-log-archiver-lambda.zip
                 parameters:
                   prefixStack: false
-                  bucket: targeting-dist
                   fileName: email-mvt-pixel-log-archiver-lambda.zip
                   functionNames:
                     - EmailMVTPixelLogArchiverLambda-


### PR DESCRIPTION
## What does this change?

This removes the Riff Raff bucket from config. This fixes a warning when deploying through Riff Raff. By default the bucket will be discovered by looking it up in parameter store.