### PR TITLE
Update Email MVT Pixel system to GuCDK v2

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,8 +1,32 @@
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
+import { EmailMVTPixel } from '../lib/email-mvt-pixel';
+import { EmailMVTPixelCertificate } from '../lib/email-mvt-pixel-certificate';
 import { EmailMVTPixelLogArchiver } from '../lib/email-mvt-pixel-log-archiver';
 
 const app = new App();
+// Deployed in us-east-1 so it can be used by CloudFront
+new EmailMVTPixelCertificate(app, 'EmailMVTPixelCertificate-TEST', {
+	app: 'EmailMVTPixelCertificate',
+	stack: 'targeting',
+	stage: 'TEST',
+});
+// Deployed in us-east-1 so it can be used by CloudFront
+new EmailMVTPixelCertificate(app, 'EmailMVTPixelCertificate-PROD', {
+	app: 'EmailMVTPixelCertificate',
+	stack: 'targeting',
+	stage: 'PROD',
+});
+new EmailMVTPixel(app, 'EmailMVTPixel-TEST', {
+	app: 'EmailMVTPixel',
+	stack: 'targeting',
+	stage: 'TEST',
+});
+new EmailMVTPixel(app, 'EmailMVTPixel-PROD', {
+	app: 'EmailMVTPixel',
+	stack: 'targeting',
+	stage: 'PROD',
+});
 new EmailMVTPixelLogArchiver(app, 'EmailMVTPixelLogArchiver-TEST', {
 	stack: 'targeting',
 	stage: 'TEST',

--- a/cdk/lib/__snapshots__/email-mvt-pixel.test.ts.snap
+++ b/cdk/lib/__snapshots__/email-mvt-pixel.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`The EmailMVTPixel stack matches the snapshot 1`] = `Object {}`;

--- a/cdk/lib/email-mvt-pixel-certificate.ts
+++ b/cdk/lib/email-mvt-pixel-certificate.ts
@@ -20,9 +20,11 @@ export class EmailMVTPixelCertificate extends GuStack {
 			description: 'Hosted Zone Name to register automatic validation',
 		});
 
-		const domainNamePrefix = `email${(props.stage === 'PROD') ? '' : `-${props.stage.toLowerCase()}`}`;
+		const domainNamePrefix = `email${
+			props.stage === 'PROD' ? '' : `-${props.stage.toLowerCase()}`
+		}`;
 
-		const domainName = `${domainNamePrefix}.${hostedZoneName.valueAsString}`
+		const domainName = `${domainNamePrefix}.${hostedZoneName.valueAsString}`;
 
 		new GuCertificate(this, {
 			app: props.app,

--- a/cdk/lib/email-mvt-pixel-certificate.ts
+++ b/cdk/lib/email-mvt-pixel-certificate.ts
@@ -1,0 +1,31 @@
+import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuStringParameter } from '@guardian/cdk/lib/constructs/core/parameters/base';
+import type { App } from 'aws-cdk-lib';
+
+interface EmailMVTPixelCertificateProps extends GuStackProps {
+	app: string;
+}
+
+export class EmailMVTPixelCertificate extends GuStack {
+	constructor(scope: App, id: string, props: EmailMVTPixelCertificateProps) {
+		super(scope, id, props);
+
+		const hostedZoneParameter = new GuStringParameter(this, 'Hosted Zone ID', {
+			description: 'Hosted Zone ID to register automatic validation',
+		});
+
+		const hostedZoneName = new GuStringParameter(this, 'Hosted Zone Name', {
+			description: 'Hosted Zone Name to register automatic validation',
+		});
+
+		new GuCertificate(this, {
+			app: props.app,
+			domainName: `email-${props.stage.toLowerCase()}.${
+				hostedZoneName.valueAsString
+			}`,
+			hostedZoneId: hostedZoneParameter.valueAsString,
+		});
+	}
+}

--- a/cdk/lib/email-mvt-pixel-certificate.ts
+++ b/cdk/lib/email-mvt-pixel-certificate.ts
@@ -20,11 +20,13 @@ export class EmailMVTPixelCertificate extends GuStack {
 			description: 'Hosted Zone Name to register automatic validation',
 		});
 
+		const domainNamePrefix = `email${(props.stage === 'PROD') ? '' : `-${props.stage.toLowerCase()}`}`;
+
+		const domainName = `${domainNamePrefix}.${hostedZoneName.valueAsString}`
+
 		new GuCertificate(this, {
 			app: props.app,
-			domainName: `email-${props.stage.toLowerCase()}.${
-				hostedZoneName.valueAsString
-			}`,
+			domainName: domainName,
 			hostedZoneId: hostedZoneParameter.valueAsString,
 		});
 	}

--- a/cdk/lib/email-mvt-pixel-log-archiver.ts
+++ b/cdk/lib/email-mvt-pixel-log-archiver.ts
@@ -1,7 +1,7 @@
 import { GuScheduledLambda } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { GuStringParameter } from "@guardian/cdk/lib/constructs/core/parameters/base";
+import { GuStringParameter } from '@guardian/cdk/lib/constructs/core/parameters/base';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';

--- a/cdk/lib/email-mvt-pixel-log-archiver.ts
+++ b/cdk/lib/email-mvt-pixel-log-archiver.ts
@@ -1,6 +1,7 @@
 import { GuScheduledLambda } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuStringParameter } from "@guardian/cdk/lib/constructs/core/parameters/base";
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
@@ -14,25 +15,17 @@ export class EmailMVTPixelLogArchiver extends GuStack {
 
 		if (!(props.stage === 'TEST' || props.stage === 'PROD')) return;
 
+		const logFilesBucket = new GuStringParameter(this, 'Log Files Bucket', {
+			description: 'S3 bucket containing CloudFront log files to process',
+		});
+
 		const functionName = `EmailMVTPixelLogArchiverLambda-${props.stage}`;
 
-		const sourceBucketNameStagePrefix =
-			props.stage === 'PROD' ? 'logs-email.' : `logs-email-test.`;
-		const sourceBucketNameSuffix = 'mvt.theguardian.com';
 		const desinationBucketNamePrefix = props.stage === 'PROD' ? '' : `test-`;
 		const destinationBucketNameSuffix = 'ophan-raw-email-mvt-pixel-logs';
 
 		// Create non-source and destination buckets
 		if (props.stage !== 'PROD') {
-			new GuS3Bucket(this, `SourceS3Bucket`, {
-				app: id,
-				bucketName: `${sourceBucketNameStagePrefix}${sourceBucketNameSuffix}`,
-				lifecycleRules: [
-					{
-						expiration: Duration.days(28),
-					},
-				],
-			});
 			new GuS3Bucket(this, `DestinationS3Bucket`, {
 				app: id,
 				bucketName: `${desinationBucketNamePrefix}${destinationBucketNameSuffix}`,
@@ -68,8 +61,8 @@ export class EmailMVTPixelLogArchiver extends GuStack {
 				new PolicyStatement({
 					sid: 'GiveLambdaAccessToSourceBucket',
 					resources: [
-						`arn:aws:s3:::${sourceBucketNameStagePrefix}${sourceBucketNameSuffix}`,
-						`arn:aws:s3:::${sourceBucketNameStagePrefix}${sourceBucketNameSuffix}/*`,
+						`arn:aws:s3:::${logFilesBucket.valueAsString}`,
+						`arn:aws:s3:::${logFilesBucket.valueAsString}/*`,
 					],
 					actions: ['s3:GetObject', 's3:ListBucket'],
 				}),
@@ -88,7 +81,7 @@ export class EmailMVTPixelLogArchiver extends GuStack {
 			],
 			monitoringConfiguration: { noMonitoring: true },
 			environment: {
-				source_s3_bucket: `${sourceBucketNameStagePrefix}${sourceBucketNameSuffix}`,
+				source_s3_bucket: logFilesBucket.valueAsString,
 				destination_s3_bucket: `${desinationBucketNamePrefix}${destinationBucketNameSuffix}`,
 			},
 		});

--- a/cdk/lib/email-mvt-pixel.ts
+++ b/cdk/lib/email-mvt-pixel.ts
@@ -9,11 +9,7 @@ import type { App } from 'aws-cdk-lib';
 import { aws_cloudfront, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { ViewerCertificate } from 'aws-cdk-lib/aws-cloudfront';
-import {
-	ARecord,
-	HostedZone,
-	RecordTarget,
-} from 'aws-cdk-lib/aws-route53';
+import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 
 interface EmailMVTPixelProps extends GuStackProps {
@@ -36,7 +32,9 @@ export class EmailMVTPixel extends GuStack {
 			app: props.app,
 		});
 
-		const domainNamePrefix = `email${(props.stage === 'PROD') ? '' : `-${props.stage.toLowerCase()}`}`;
+		const domainNamePrefix = `email${
+			props.stage === 'PROD' ? '' : `-${props.stage.toLowerCase()}`
+		}`;
 
 		const cloudfrontAlias = `${domainNamePrefix}.${hostedZoneName.valueAsString}`;
 

--- a/cdk/lib/email-mvt-pixel.ts
+++ b/cdk/lib/email-mvt-pixel.ts
@@ -36,9 +36,9 @@ export class EmailMVTPixel extends GuStack {
 			app: props.app,
 		});
 
-		const cloudfrontAlias = `email-${props.stage.toLowerCase()}.${
-			hostedZoneName.valueAsString
-		}`;
+		const domainNamePrefix = `email${(props.stage === 'PROD') ? '' : `-${props.stage.toLowerCase()}`}`;
+
+		const cloudfrontAlias = `${domainNamePrefix}.${hostedZoneName.valueAsString}`;
 
 		const certificate = Certificate.fromCertificateArn(
 			this,

--- a/cdk/lib/email-mvt-pixel.ts
+++ b/cdk/lib/email-mvt-pixel.ts
@@ -9,7 +9,7 @@ import type { App } from 'aws-cdk-lib';
 import { aws_cloudfront, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { ViewerCertificate } from 'aws-cdk-lib/aws-cloudfront';
-import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
+import { AaaaRecord, ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 
 interface EmailMVTPixelProps extends GuStackProps {
@@ -99,6 +99,13 @@ export class EmailMVTPixel extends GuStack {
 		);
 
 		new ARecord(this, 'Route53AliasToCloudFront', {
+			target: RecordTarget.fromAlias(new CloudFrontTarget(distribution)),
+			zone: hostedZone,
+			recordName: cloudfrontAlias,
+			ttl: Duration.hours(1),
+		});
+
+		new AaaaRecord(this, 'Route53IPv6AliasToCloudFront', {
 			target: RecordTarget.fromAlias(new CloudFrontTarget(distribution)),
 			zone: hostedZone,
 			recordName: cloudfrontAlias,

--- a/cdk/lib/email-mvt-pixel.ts
+++ b/cdk/lib/email-mvt-pixel.ts
@@ -1,0 +1,110 @@
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import {
+	GuCertificateArnParameter,
+	GuStack,
+} from '@guardian/cdk/lib/constructs/core';
+import { GuStringParameter } from '@guardian/cdk/lib/constructs/core/parameters/base';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import type { App } from 'aws-cdk-lib';
+import { aws_cloudfront, Duration } from 'aws-cdk-lib';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { ViewerCertificate } from 'aws-cdk-lib/aws-cloudfront';
+import {
+	ARecord,
+	HostedZone,
+	RecordTarget,
+} from 'aws-cdk-lib/aws-route53';
+import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
+
+interface EmailMVTPixelProps extends GuStackProps {
+	app: string;
+}
+
+export class EmailMVTPixel extends GuStack {
+	constructor(scope: App, id: string, props: EmailMVTPixelProps) {
+		super(scope, id, props);
+
+		const hostedZoneParameter = new GuStringParameter(this, 'Hosted Zone ID', {
+			description: 'Hosted Zone ID of Route 53 entry',
+		});
+
+		const hostedZoneName = new GuStringParameter(this, 'Hosted Zone Name', {
+			description: 'Hosted Zone Name of Route 53 entry',
+		});
+
+		const certificateArnParameter = new GuCertificateArnParameter(this, {
+			app: props.app,
+		});
+
+		const cloudfrontAlias = `email-${props.stage.toLowerCase()}.${
+			hostedZoneName.valueAsString
+		}`;
+
+		const certificate = Certificate.fromCertificateArn(
+			this,
+			id,
+			certificateArnParameter.valueAsString,
+		);
+
+		const logFiles = new GuS3Bucket(this, `CloudFrontLogsS3Bucket`, {
+			app: props.app,
+			bucketName: `email-mvt-pixel-cloudfront-logs-${props.stage.toLowerCase()}`,
+			lifecycleRules: [
+				{
+					expiration: Duration.days(28),
+				},
+			],
+		});
+
+		const pixelSourceFiles = new GuS3Bucket(this, 'PixelS3Bucket', {
+			app: props.app,
+			bucketName: `email-mvt-pixel-files-${props.stage.toLowerCase()}`,
+		});
+
+		const originAccessIdentity = new aws_cloudfront.OriginAccessIdentity(
+			this,
+			`OriginAccessIdentity`,
+			{
+				comment: `Access Identity for ${pixelSourceFiles.bucketName}`,
+			},
+		);
+
+		const distribution = new aws_cloudfront.CloudFrontWebDistribution(
+			this,
+			`PixelCloudFrontDistribution`,
+			{
+				viewerCertificate: ViewerCertificate.fromAcmCertificate(certificate, {
+					aliases: [cloudfrontAlias],
+				}),
+				loggingConfig: {
+					bucket: logFiles,
+				},
+				originConfigs: [
+					{
+						s3OriginSource: {
+							s3BucketSource: pixelSourceFiles,
+							originAccessIdentity: originAccessIdentity,
+						},
+						behaviors: [{ isDefaultBehavior: true }],
+					},
+				],
+			},
+		);
+
+		const hostedZone = HostedZone.fromHostedZoneAttributes(
+			this,
+			'HostedZoneToSetUpCNAME',
+			{
+				zoneName: hostedZoneName.valueAsString,
+				hostedZoneId: hostedZoneParameter.valueAsString,
+			},
+		);
+
+		new ARecord(this, 'Route53AliasToCloudFront', {
+			target: RecordTarget.fromAlias(new CloudFrontTarget(distribution)),
+			zone: hostedZone,
+			recordName: cloudfrontAlias,
+			ttl: Duration.hours(1),
+		});
+	}
+}


### PR DESCRIPTION
Upgraded the EmailMVTPixel stack to use GuCDKv2, re-provisioning the certificate, plus S3 pixel file bucket, CloudFront destination, CloudFront log S3 bucket and Route53 records.

Everything has been deployed now, all 6 CloudFormation stacks are using the versions generated as part of this change, the old code will be deleted in a future PR, which will reference this one. That'll make Snyk happy.

The Lambda functions as part of the EmailMVTPixelArchiver have been updated to reference the new S3 buckets in their ENV config, and all tested. Only the Lambda CFN and Code is deployable via RiffRaff, as it's the only part requiring a build or likely to change over time (aside of CDK upgrades).

There was at most 5 minutes of downtime.

This PR addresses:

<img width="891" alt="Screenshot 2023-03-15 at 15 13 47" src="https://user-images.githubusercontent.com/1515970/225354506-71b2ffd4-3a65-43b5-bc1f-0d8727c7b7f2.png">

This change also remediates 5 out of the 9:

<img width="677" alt="Screenshot 2023-03-15 at 15 15 40" src="https://user-images.githubusercontent.com/1515970/225355371-5c35c24d-5889-42ca-98f2-a3ef0cc816b0.png">

