### PR TITLE
Enable HTTP/3 as a protocol option for the pixel

### DIFF
--- a/cdk/lib/email-mvt-pixel.ts
+++ b/cdk/lib/email-mvt-pixel.ts
@@ -8,8 +8,13 @@ import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
 import { aws_cloudfront, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
-import { ViewerCertificate } from 'aws-cdk-lib/aws-cloudfront';
-import { AaaaRecord, ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
+import { HttpVersion, ViewerCertificate } from 'aws-cdk-lib/aws-cloudfront';
+import {
+	AaaaRecord,
+	ARecord,
+	HostedZone,
+	RecordTarget,
+} from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 
 interface EmailMVTPixelProps extends GuStackProps {
@@ -86,6 +91,7 @@ export class EmailMVTPixel extends GuStack {
 						behaviors: [{ isDefaultBehavior: true }],
 					},
 				],
+				httpVersion: HttpVersion.HTTP2_AND_3,
 			},
 		);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Enabling HTTP/3 as a protocol option for the pixel. This may benefit some clients in making their email complete its render marginally faster.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Browser shows HTTP3 response:
<img width="742" alt="Screenshot 2023-03-20 at 10 41 57" src="https://user-images.githubusercontent.com/1515970/226316723-4fd1c61f-4f0c-4a22-8fab-58295dbde75c.png">

Also HTTP/2 works fine (when HTTP/3 is disabled in about:config):
<img width="742" alt="Screenshot 2023-03-20 at 10 40 14" src="https://user-images.githubusercontent.com/1515970/226316783-f9f52605-30c6-4328-a7c6-2202ee41cf71.png">

No reported errors in CloudFront metrics.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
No reported errors in CloudFront metrics.
Data platform query shows no radical dip in average traffic (20 March 2023 was a little lower than 16 and 17th, however not a cause for alarm. Will keep monitoring.):
```SELECT opened_date, COUNT(*) FROM `datalake.email_mvt_pixel_impressions` WHERE dt >= "2023-03-16" GROUP BY 1 ORDER BY 1```
