### PR TITLE
Dont set Access Control List for data written to s3 bucket: "ophan-raw-email-mvt-pixel-logs"

### DIFF
--- a/cdk/lib/email-mvt-pixel-log-archiver.ts
+++ b/cdk/lib/email-mvt-pixel-log-archiver.ts
@@ -71,7 +71,7 @@ export class EmailMVTPixelLogArchiver extends GuStack {
 					resources: [
 						`arn:aws:s3:::${desinationBucketNamePrefix}${destinationBucketNameSuffix}/*`,
 					],
-					actions: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+					actions: ['s3:GetObject', 's3:PutObject'],
 				}),
 			],
 			rules: [

--- a/email-mvt-archive/src/email-mvt-pixel-log-archiver-lambda.ts
+++ b/email-mvt-archive/src/email-mvt-pixel-log-archiver-lambda.ts
@@ -50,7 +50,6 @@ function processTransfer(
     }).promise()
       .then(() => Promise.resolve('skipped'))
       .catch(() => s3.copyObject({
-        ACL: 'bucket-owner-read',
         Bucket: `${destinationS3Bucket}/dt=${fileToTransfer.destinationFolder}`,
         CopySource: `${sourceS3Bucket}/${fileToTransfer.sourceFileName}`,
         Key: fileToTransfer.sourceFileName


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This stops sending an Access Control List (ACL) with the data written to the "ophan-raw-email-mvt-pixel-logs" bucket.
The reason this change is needed is that allowing an external entity to set ACL's for an s3 bucket contravenes one of the FSBP security standards - specifically [S3.6: "S3 general purpose bucket policies should restrict access to other AWS accounts"](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-6) 

This change will be made with corresponding changes in the S3 bucket and related infrastructure in the ophan-data-lake repository to ensure the bucket is using the ACL's specified by the account owner and no longer expecting one to be sent with the data.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
