### PR TITLE
Increase lambda timeout

### DIFF
--- a/cdk/lib/email-mvt-pixel-log-archiver.ts
+++ b/cdk/lib/email-mvt-pixel-log-archiver.ts
@@ -44,7 +44,7 @@ export class EmailMVTPixelLogArchiver extends GuStack {
 			handler: 'email-mvt-pixel-log-archiver-lambda.handler',
 			runtime: Runtime.NODEJS_24_X,
 			memorySize: 768,
-			timeout: Duration.seconds(60),
+			timeout: Duration.seconds(120),
 			initialPolicy: [
 				new PolicyStatement({
 					sid: 'CreateLogGroupForFunction',


### PR DESCRIPTION
The `EmailMVTPixelLogArchiverLambda-PROD ` lambda has started timing out.
Until recently it was taking about 50 seconds, but it's now ~70 seconds.